### PR TITLE
Add option to set the maximum number of connections

### DIFF
--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -201,6 +201,7 @@ class PGTest(object):
         copy_cluster - str, copies cluster from this path
         base_dir - str, path to the base directory to init the cluster
         pg_ctl - str, path to the pg_ctl executable to use
+        max_connections - int, maximum number of connections to the cluster
 
     Attributes:
         PGTest.port - int, port number bound by PGTest
@@ -251,7 +252,7 @@ class PGTest(object):
     # pylint: disable=too-many-arguments
     def __init__(self, username='postgres', port=None, log_file=None,
                  no_cleanup=False, copy_cluster=None, base_dir=None,
-                 pg_ctl=None):
+                 pg_ctl=None, max_connections=5):
         self._database = 'postgres'
 
         assert is_valid_db_object_name(username), (
@@ -300,6 +301,7 @@ class PGTest(object):
             self._listen_socket_dir = None
 
         self._no_cleanup = no_cleanup
+        self._max_connections = max_connections
 
         self._create_dirs()
         self._init_base_dir()
@@ -391,10 +393,11 @@ class PGTest(object):
 
         cmd = ('"{pg_ctl}" start -D "{cluster}" -l "{log_file}" -o "-F -d 1 '
                '-p {port} -c logging_collector=off '
-               '-N 5 {socket_opt}"').format(pg_ctl=self._pg_ctl_exe,
+               '-N {max_connections} {socket_opt}"').format(pg_ctl=self._pg_ctl_exe,
                                             cluster=self._cluster,
                                             log_file=self._log_file,
                                             port=self._port,
+                                            max_connections=self._max_connections,
                                             socket_opt=socket_opt)
         try:
             subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -31,6 +31,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import numbers
 import time
 import datetime
 if sys.version_info >= (3, 0):
@@ -301,6 +302,8 @@ class PGTest(object):
             self._listen_socket_dir = None
 
         self._no_cleanup = no_cleanup
+        assert isinstance(max_connections, numbers.Integral), (
+            'Maximum number of connections must be an integer.')
         self._max_connections = max_connections
 
         self._create_dirs()
@@ -317,10 +320,11 @@ class PGTest(object):
     def __repr__(self):
         return ('{!s}(database={!r}, username={!r}, port={!s}, log_file={!r}, '
                 'no_cleanup={!r}, copy_cluster={!r}, cluster={!r}, '
-                'pg_ctl={!r})').format(
+                'pg_ctl={!r}), max_connections={!r}').format(
                     self.__class__.__name__, self._database, self._username,
                     self._port, self._log_file, self._no_cleanup,
-                    self._copy_cluster, self._base_dir, self._pg_ctl_exe)
+                    self._copy_cluster, self._base_dir, self._pg_ctl_exe,
+                    self._max_connections)
 
     @property
     def port(self):

--- a/test/test.py
+++ b/test/test.py
@@ -118,8 +118,7 @@ class TestPGTestWithParameters(unittest.TestCase, CustomAssertions):
             with psycopg2.connect(**pg.dsn) as connection:
                 with connection.cursor() as cursor:
                     cursor.execute('SHOW max_connections;')
-                    max_connections = int(list(cursor)[0][0])
-                    self.assertTrue(max_connectios == 10)
+                    self.assertEqual(int(list(cursor)[0][0]), 10)
 
     def test_invalid_max_connections_exit(self):
         with self.assertRaises(AssertionError):

--- a/test/test.py
+++ b/test/test.py
@@ -113,6 +113,17 @@ class TestPGTestWithParameters(unittest.TestCase, CustomAssertions):
             self.assertTrue(pgtest.is_server_running(pg.cluster))
         shutil.rmtree(temp_dir, ignore_errors=True)
 
+    def test_max_connections_valid(self):
+        with pgtest.PGTest(max_connections=10) as pg:
+            with psycopg2.connect(**pg.dsn) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute('SHOW max_connections;')
+                    max_connections = int(list(cursor)[0][0])
+                    self.assertTrue(max_connectios == 10)
+
+    def test_invalid_max_connections_exit(self):
+        with self.assertRaises(AssertionError):
+            pgtest.PGTest(max_connections=3.5)
 
 class TestPGTestNoParameters(unittest.TestCase, CustomAssertions):
 


### PR DESCRIPTION
Added a keyword argument ``max_connections`` to set the maximum number of connections. The default value (5) corresponds to the previous behavior.