### PR TITLE
Ignore error of postgres install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo apt-get install locate
   - sudo service postgresql stop
   - sudo apt-get remove postgresql
-  - sudo apt-get install postgresql
+  - sudo apt-get install postgresql || true
   - sudo updatedb
 dist: trusty
 addons:


### PR DESCRIPTION
The Travis build was previously broken due to some error in the configure stage of the postgres install. Not sure why, but simply ignoring this error fixes the build.