### PR TITLE
Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,40 +1,89 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
+variables:
+  TOXENV: py36,py27
 
 trigger:
 - master
 
 jobs:
-- job: before_install
-  strategy:
-    matrix:
-      Python27:
-        python.version: '2.7'
-      Python36:
-        python.version: '3.6'
-    maxParallel: 4
+- job: Ubuntu
   pool:
     vmImage: 'Ubuntu-16.04'
   steps:
-  - bash: |
+  - script: |
       sudo apt-get update &&
-      sudo apt-get -y install postgresql locate &&
+      sudo apt-get -y install postgresql &&
       sudo updatedb 
     displayName: Install postgresql
 
-  - script: locate pg_ctl
-
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '$(python.version)'
+      versionSpec: '3.6'
       architecture: 'x64'
-
-  - script: locate pg_ctl
 
   - script: python -m pip install tox
     displayName: 'Install tox'
    
   - script: tox
     displayName: 'Run tox tests'
+
+
+- job: MacOS
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+
+  # alternative: use homebrew
+  #- script: brew install postgresql
+  #  displayName: Install postgresql
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops&tabs=macos
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+
+  - script: conda install --yes --quiet postgresql==10.5
+    displayName: Install postgresql
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+
+  - script: python -m pip install tox
+    displayName: 'Install tox'
+   
+  - script: tox
+    displayName: 'Run tox tests'
+
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  variables:
+    TOXENV: py36
+  steps:
+
+  # see https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops&tabs=macos
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+
+  # needed for access to pg_ctl
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Library\bin"
+    displayName: Add conda library to PATH
+
+  - script: conda install --yes --quiet postgresql==10.5
+    displayName: Install postgresql
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+
+  - script: python -m pip install tox
+    displayName: 'Install tox'
+   
+  - script: tox
+    displayName: 'Run tox tests'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,40 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+jobs:
+- job: before_install
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python36:
+        python.version: '3.6'
+    maxParallel: 4
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+  - bash: |
+      sudo apt-get update &&
+      sudo apt-get -y install postgresql locate &&
+      sudo updatedb 
+    displayName: Install postgresql
+
+  - script: locate pg_ctl
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: locate pg_ctl
+
+  - script: python -m pip install tox
+    displayName: 'Install tox'
+   
+  - script: tox
+    displayName: 'Run tox tests'

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -109,7 +109,7 @@ def which(in_file):
         except subprocess.CalledProcessError:
             pass
 
-        return
+        raise ValueError("'{}' could not be found.".format(in_file))
 
 def is_valid_port(port):
     """Checks a port number to check if it is within the valid range

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -46,6 +46,9 @@ class TimeoutError(BaseException):
     def __init__(self, message):
         super(TimeoutError, self).__init__(message)
 
+def is_executable(file_path):
+    """Checks whether file_path points to executable file."""
+    return file_path and os.path.isfile(file_path) and os.access(file_path, os.X_OK)
 
 def which(in_file):
     """Finds an executable program in the system and returns the program name
@@ -59,30 +62,31 @@ def which(in_file):
         in_file - str, program name or path to find
 
     Returns:
-        file_path - str, normalised path to file found or None if not found
+        file_path - str, normalised path to file found
+        
+    Raises:
+        FileNotFoundError, if no executable file not found
     """
     if not isinstance(in_file, basestring):
         raise TypeError('file must be a valid string')
     path_no_ext, _ = os.path.splitext(in_file)
     path_with_exe = path_no_ext + '.exe'
+
     # Look for the exe at the path supplied
     if os.path.split(path_no_ext)[0]:
-        if os.path.isfile(in_file):
-            file_path = in_file
-        elif os.path.isfile(path_with_exe):
-            file_path = path_with_exe
-        if os.access(file_path, os.X_OK):
-            return os.path.normpath(file_path)
+        if is_executable(in_file):
+            return os.path.normpath(in_file)
+        elif is_executable(path_with_exe):
+            return os.path.normpath(path_with_exe)
+    # Search inside the PATH
     else:
         for path in os.environ['PATH'].split(os.pathsep):
             file_path = os.path.join(path.strip('"'), in_file)
             file_path_with_exe = os.path.join(path.strip('"'), path_with_exe)
-            if os.path.isfile(file_path_with_exe):
-                if os.access(file_path_with_exe, os.X_OK):
-                    return os.path.normpath(file_path_with_exe)
-            elif os.path.isfile(file_path):
-                if os.access(file_path, os.X_OK):
-                    return os.path.normpath(file_path)
+            if is_executable(file_path_with_exe):
+                return os.path.normpath(file_path_with_exe)
+            elif is_executable(file_path):
+                return os.path.normpath(file_path)
 
     if not sys.platform.startswith('win'):
         # first, search default locations, inspired by Debian's PgCommon.pm
@@ -90,7 +94,7 @@ def which(in_file):
             pg_ctls = {float(re.search(r'postgresql/([\d\.]+)/bin', p).group(1)):
                     p for p in glob.glob('/usr/lib/postgresql/*/bin/' + in_file)}
             file_path = pg_ctls[max(pg_ctls)]
-            if os.access(file_path, os.X_OK):
+            if is_executable(file_path):
                 return os.path.normpath(file_path)
 
         except (AttributeError, ValueError):
@@ -104,12 +108,12 @@ def which(in_file):
             locate_cmd = ['locate', '-r', exact_file_regex]
             results = subprocess.check_output(locate_cmd)
             for file_path in results.decode('utf-8').split('\n'):
-                if os.access(file_path, os.X_OK):
+                if is_executable(file_path):
                     return os.path.normpath(file_path)
         except subprocess.CalledProcessError:
             pass
 
-        raise ValueError("'{}' could not be found.".format(in_file))
+        raise FileNotFoundError("'{}' could not be found.".format(in_file))
 
 def is_valid_port(port):
     """Checks a port number to check if it is within the valid range

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -35,9 +35,15 @@ import tempfile
 import numbers
 import time
 import datetime
+
 if sys.version_info >= (3, 0):
     unicode = str
     basestring = (str, bytes)
+
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 import pg8000
 

--- a/test/test.py
+++ b/test/test.py
@@ -15,6 +15,11 @@ import pg8000
 import psycopg2
 import sqlalchemy
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 class TestThirdPartyDrivers(unittest.TestCase):
 
     @classmethod

--- a/test/test.py
+++ b/test/test.py
@@ -15,7 +15,6 @@ import pg8000
 import psycopg2
 import sqlalchemy
 
-
 class TestThirdPartyDrivers(unittest.TestCase):
 
     @classmethod
@@ -255,15 +254,22 @@ class Test_which(unittest.TestCase):
 
     @unittest.skipIf(sys.platform.startswith('win'), 'Unix only')
     def test_unix_which_is_executable(self):
-        self.assertEqual('/bin/ping', pgtest.which('ping'))
+        if sys.platform.startswith('darwin'):
+            self.assertEqual(pgtest.which('ping'), '/sbin/ping')
+        else:
+            self.assertEqual(pgtest.which('ping'), '/bin/ping')
 
     @unittest.skipIf(sys.platform.startswith('win'), 'Unix only')
     def testunix_which_path_is_executable(self):
-        self.assertEqual('/bin/ping', pgtest.which('/bin/ping'))
+        if sys.platform.startswith('darwin'):
+            self.assertEqual(pgtest.which('/sbin/ping'), '/sbin/ping')
+        else:
+            self.assertEqual(pgtest.which('/bin/ping'), '/bin/ping')
 
     @unittest.skipIf(sys.platform.startswith('win'), 'Unix only')
     def test_unix_which_is_not_executable(self):
-        self.assertEqual(None, pgtest.which('doesnotexist'))
+        with self.assertRaises(FileNotFoundError):
+            pgtest.which('doesnotexist')
 
     def test_which_non_string(self):
         with self.assertRaises(TypeError):
@@ -271,27 +277,30 @@ class Test_which(unittest.TestCase):
 
     @unittest.skipIf(sys.platform.startswith('win'), 'Unix only')
     def test_unix_which_unicode(self):
-            self.assertEqual('/bin/ping', pgtest.which(u'ping'))
+        if sys.platform.startswith('darwin'):
+            self.assertEqual(pgtest.which(u'ping'), '/sbin/ping')
+        else:
+            self.assertEqual(pgtest.which(u'ping'), '/bin/ping')
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_unicode(self):
-            self.assertEqual('C:\\Windows\\system32\\ping.exe', pgtest.which(u'ping'))
+        self.assertEqual('C:\\Windows\\system32\\ping.exe'.lower(), pgtest.which(u'ping').lower())
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_is_executable(self):
-        self.assertEqual('C:\\Windows\\system32\\ping.exe', pgtest.which('ping'))
+        self.assertEqual('C:\\Windows\\system32\\ping.exe'.lower(), pgtest.which('ping').lower())
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_with_extension_is_executable(self):
-        self.assertEqual('C:\\Windows\\system32\\ping.exe', pgtest.which('ping.exe'))
+        self.assertEqual('C:\\Windows\\system32\\ping.exe'.lower(), pgtest.which('ping.exe').lower())
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_path_is_executable(self):
-        self.assertEqual('C:\\Windows\\system32\\ping.exe', pgtest.which('C:/Windows/system32/ping'))
+        self.assertEqual('C:\\Windows\\system32\\ping.exe'.lower(), pgtest.which('C:/Windows/system32/ping').lower())
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_path_with_extension_is_executable(self):
-        self.assertEqual('C:\\Windows\\system32\\ping.exe', pgtest.which('C:/Windows/system32/ping.exe'))
+        self.assertEqual('C:\\Windows\\system32\\ping.exe'.lower(), pgtest.which('C:/Windows/system32/ping.exe').lower())
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
     def test_windows_which_is_not_executable(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py35
 
 [testenv]
 deps=
@@ -8,7 +8,7 @@ deps=
     pylint
     flake8
     pg8000
-    psycopg2
+    psycopg2-binary
     SQLAlchemy
 commands=
     nosetests --with-coverage --cover-package=pgtest,test


### PR DESCRIPTION
fix #12 

This PR adds an [azure pipeline](https://azure.microsoft.com/en-us/services/devops/pipelines/) configuration that tests pgtest on Ubuntu 16.04, MacOS 10.13 and Windows Server 2016. See [here](https://dev.azure.com/leoteopard/aiida-repos/_build/results?buildId=45) for the build on my fork.

Further improvements/changes:

 * `pgtest.which` now raises a `FileNotFoundError` when it does not find the file it is looking for. I introduced this because the error message you got previously (` /bin/sh: 1: None: not found`) is not very helpful. One may argue that returning `None` is more analogous to what the `which` command does, but the alternative would be to check for the `None` result wherever we use the `which` function (if you prefer this, I can make the change).
 * minor fixes to tests on unix, taking into account that `ping` lives in `/sbin` on MacOS
 * minor fixes to tests on windows, taking into account that the top-level folder on windows server seems to be `windows`, not `Windows`
 * `psycopg2` just released version 2.8, and the wheels have now moved to `psycopg2-binary` (so I changed the test requirements accordingly)