### PR TITLE
Must store the subprocess for the start command, to cleanup at end

### DIFF
--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -188,6 +188,7 @@ def is_server_running(path):
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     out, _ = proc.communicate()
+    proc.wait(5)
     if out.decode('utf-8').strip() == 'pg_ctl: no server running':
         return False
     else:
@@ -210,6 +211,7 @@ def is_valid_cluster_dir(path):
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     _, err = proc.communicate()
+    proc.wait(5)
     if 'No such file or directory' in err.decode('utf-8'):
         return False
     else:
@@ -447,9 +449,10 @@ class PGTest(object):
                                             connections_opt=connections_opt,
                                             socket_opt=socket_opt)
         try:
-            subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
             self._wait_for_server_ready(5)
+            proc.wait(5)
         except:
             print('Server failed to start')
             print(self.log_file_contents)
@@ -468,6 +471,7 @@ class PGTest(object):
             _, err = proc.communicate()
             if err:
                 raise RuntimeError(err)
+            proc.wait(5)
         except:
             print(self.log_file_contents)
             self._cleanup()
@@ -507,6 +511,7 @@ class PGTest(object):
                 _, err = proc.communicate()
                 if err:
                     raise IOError(err)
+                proc.wait(5)
             assert is_valid_cluster_dir(self._cluster), (
                 'Failed to create cluster: {path}').format(path=self._cluster)
         except:


### PR DESCRIPTION
Must store the subprocess for the start command, to cleanup at end, so we don't get resource warnings