### PR TITLE
export PGTest also on top level

### DIFF
--- a/pgtest/__init__.py
+++ b/pgtest/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "1.3.1"
+
+from .pgtest import PGTest

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -36,6 +36,9 @@ import numbers
 import time
 import datetime
 
+__all__ = ('PGTest', 'is_executable', 'which', 'is_server_running', 'is_valid_cluster_dir', 'is_valid_db_object_name',
+           'is_valid_port')
+
 if sys.version_info >= (3, 0):
     unicode = str
     basestring = (str, bytes)
@@ -415,7 +418,7 @@ class PGTest(object):
             >>> pg = pgtest.PGTest()
             >>> # e.g. psycopg2 requires a dsn like:
             >>> # psycopg2.connect(database="test",
-            >>> ...user="postgres", password="secret")
+            >>> # ...user="postgres", password="secret")
             >>> cnxn = psycopg2.connect(**pg.dsn)
         """
         return {'port': self._port,


### PR DESCRIPTION
fixes #2 

I can see no harm in exporting the PGTest class also at the top level of
the package. It is the main part of the package of interest to users and
this reduces typing.