### PR TITLE
Set the database encoding as UTF8

### DIFF
--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -233,6 +233,7 @@ class PGTest(object):
            Note: PostgreSQL may require a minimum number of allowed connections
              (e.g. 11 connections with PostgreSQL 10 on Ubuntu 18.04 or 14
              connections with PostgresSQL 11 on Ubuntu 19.04)
+        default_encoding - str, default encoding, for example, 'UTF8'
 
     Attributes:
         PGTest.port - int, port number bound by PGTest
@@ -283,7 +284,7 @@ class PGTest(object):
     # pylint: disable=too-many-arguments
     def __init__(self, username='postgres', port=None, log_file=None,
                  no_cleanup=False, copy_cluster=None, base_dir=None,
-                 pg_ctl=None, max_connections=None):
+                 pg_ctl=None, max_connections=None, default_encoding=None):
         self._database = 'postgres'
         self._proc_start = None
 
@@ -336,6 +337,11 @@ class PGTest(object):
         assert max_connections is None or isinstance(max_connections, numbers.Integral), (
             'Maximum number of connections must be an integer.')
         self._max_connections = max_connections
+
+        if default_encoding:
+            self._default_encoding = default_encoding
+        else:
+            self._default_encoding = None
 
         self._create_dirs()
         self._init_base_dir()
@@ -500,10 +506,16 @@ class PGTest(object):
                 shutil.rmtree(self._cluster)
                 shutil.copytree(self._copy_cluster, self._cluster)
             else:
+                if self._default_encoding is None:
+                    encoding_opt = ''
+                else:
+                    encoding_opt = '--encoding {default_encoding}'.format(default_encoding=self._default_encoding)
+
                 cmd = ('"{pg_ctl}" initdb -D "{cluster}" -o "-U {username} -A '
-                       'trust -E UTF8"').format(pg_ctl=self._pg_ctl_exe,
+                       'trust {encoding_opt}"').format(pg_ctl=self._pg_ctl_exe,
                                         cluster=self._cluster,
-                                        username=self._username)
+                                        username=self._username,
+                                        encoding_opt=encoding_opt)
 
                 proc = subprocess.Popen(cmd, shell=True,
                                         stdout=subprocess.PIPE,

--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -501,7 +501,7 @@ class PGTest(object):
                 shutil.copytree(self._copy_cluster, self._cluster)
             else:
                 cmd = ('"{pg_ctl}" initdb -D "{cluster}" -o "-U {username} -A '
-                       'trust"').format(pg_ctl=self._pg_ctl_exe,
+                       'trust -E UTF8"').format(pg_ctl=self._pg_ctl_exe,
                                         cluster=self._cluster,
                                         username=self._username)
 


### PR DESCRIPTION
In my Brazilian Portuguese application, using accented characters was giving unicode errors on save using pgtest. It looks like that for some reason, the database wasn't being created with the usual UTF8 encoding. A parameter is need for pg_ctl to ensure this, so I added it. I think this should not influence other users.