### PR TITLE
Catch exception if locate command is missing

### DIFF
--- a/pgtest/pgtest.py
+++ b/pgtest/pgtest.py
@@ -119,7 +119,7 @@ def which(in_file):
             for file_path in results.decode('utf-8').split('\n'):
                 if is_executable(file_path):
                     return os.path.normpath(file_path)
-        except subprocess.CalledProcessError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             pass
 
         raise FileNotFoundError("'{}' could not be found.".format(in_file))


### PR DESCRIPTION
Tested on Ubuntu 20.04 image with Python 3.9

Closes #25 

EDIT: I am not sure what this does on Windows and don't really have a machine to test this. Perhaps we could consider catching the parent OSError exception....